### PR TITLE
fix: correct Blue IDs to match new blueId calculation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     implementation("com.github.java-json-tools:json-patch:1.13")
 
     // Blue Language
-    implementation("blue.language:blue-language-java:0.7.2")
+    implementation("blue.language:blue-language-java:0.7.3")
 
     implementation gradleApi()
     implementation localGroovy()

--- a/src/main/java/blue/contract/packager/BluePackageExporter.java
+++ b/src/main/java/blue/contract/packager/BluePackageExporter.java
@@ -13,7 +13,7 @@ public class BluePackageExporter {
     public static final String ROOT_DEPENDENCY = "ROOT";
     public static final String BLUE_FILE_EXTENSION = ".blue";
     public static final String EXTENDS_FILE_NAME = "_extends.txt";
-    public static final String REPLACE_INLINE_TYPES_WITH_BLUE_ID_TRANSFORMER_BLUE_ID = "648mybP3oHoi8kx6HvYzw6Jtuz6BjUpGPk1r2DpCq7e4";
+    public static final String REPLACE_INLINE_TYPES_WITH_BLUE_ID_TRANSFORMER_BLUE_ID = "27B7fuxQCS1VAptiCPc2RMkKoutP5qxkh3uDxZ7dr6Eo";
 
     public static List<BluePackage> exportPackages(String rootDir, DependencyGraphBuilder builder) throws IOException {
         DependencyGraph graph = builder.buildDependencyGraph(rootDir);

--- a/src/main/java/blue/contract/processor/StandardProcessorsProvider.java
+++ b/src/main/java/blue/contract/processor/StandardProcessorsProvider.java
@@ -39,12 +39,12 @@ public class StandardProcessorsProvider implements StepProcessorProvider {
         }
 
         Map<String, Function<Node, StepProcessor>> processorMap = new HashMap<>();
-        processorMap.put("81yruzcExdbod4xZ49qxZpnaWEnDEiGZ7xe5sh13AQ7g", node -> new ExpectEventStepProcessor(node, expressionEvaluator));
-        processorMap.put("3uFwcdCx8Sdw43hGbBL3t9YGRocLbAewHzzxbrKAkUKF", node -> new TriggerEventStepProcessor(node, expressionEvaluator));
-        processorMap.put("6PsXX3HF74kESc6eg58z8kNwzqD64xQ3PjGPUppzcWg6", node -> new UpdateStepProcessor(node, expressionEvaluator));
-        processorMap.put("D7bzHri8CT5j7aZtWVLcTAXkVdrrhe9inGbQopszrtbB", node -> new InitializeLocalContractStepProcessor(node, expressionEvaluator));
-        processorMap.put("8ZZiA8FgJC1scybYXCVt4Qf9Zh9LQGMLChDtVmDfZh9o", node -> new WorkflowFunctionStepProcessor(node, expressionEvaluator, jsExecutor));
-        processorMap.put("5TrdtnYzrxenA6HLujs6z2Q5gLcS9heyrr3HpBNSbeFb", node -> new JSCodeStepProcessor(node, expressionEvaluator, jsExecutor, blue));
+        processorMap.put("3UXhfjDZ8EMopVJrDxS8Gf2USfLZvzFGpzyzconyzAkm", node -> new ExpectEventStepProcessor(node, expressionEvaluator));
+        processorMap.put("6sdEGwtrVJhdto5CsDzm81YrJtHTZrdsenZkyCWJLniU", node -> new TriggerEventStepProcessor(node, expressionEvaluator));
+        processorMap.put("DpdjTNXQdgWGxDyB1LLUNFvxSNNM9L9qGMoKZxzYMDoB", node -> new UpdateStepProcessor(node, expressionEvaluator));
+        processorMap.put("FF88BRKtRXQ2cCCBR28cFUB5mHdPsWjj8gVBgz4VmQm7", node -> new InitializeLocalContractStepProcessor(node, expressionEvaluator));
+        processorMap.put("EZjDfHEnvvwhP14FXdzLSBXBW9BcanYefW9mRfZNLh7D", node -> new WorkflowFunctionStepProcessor(node, expressionEvaluator, jsExecutor));
+        processorMap.put("CFKAD5Up8XpNyPHwRBEwiwSUdfFUoGqVVsW29k6te88p", node -> new JSCodeStepProcessor(node, expressionEvaluator, jsExecutor, blue));
 
         return Optional.ofNullable(processorMap.get(step.getType().getBlueId())).map(func -> func.apply(step));
     }

--- a/src/main/resources/blue-repository/Chess/Chess.blue
+++ b/src/main/resources/blue-repository/Chess/Chess.blue
@@ -73,7 +73,7 @@ workflows:
       - name: ProcessMove
         type: JavaScript Code Step
         code: |
-          const chessModule = importBlueESModule('blue:FQP53g6UNu75EeEDmTX8mKHqoNSLQgYxQxpFhAzKyHhJ');
+          const chessModule = importBlueESModule('blue:9uGqgr62FtodKDH1KqGb1syeqHfSRo7ySQ5KY8bTutNu');
           const Chess = chessModule.Chess;
 
           function checkMove(from, to, position) {

--- a/src/main/resources/blue-repository/Chess/ChessAssisted.blue
+++ b/src/main/resources/blue-repository/Chess/ChessAssisted.blue
@@ -73,7 +73,7 @@ workflows:
       - name: ProcessMove
         type: JavaScript Code Step
         code: |
-          const chessModule = importBlueESModule('blue:FQP53g6UNu75EeEDmTX8mKHqoNSLQgYxQxpFhAzKyHhJ');
+          const chessModule = importBlueESModule('blue:9uGqgr62FtodKDH1KqGb1syeqHfSRo7ySQ5KY8bTutNu');
           const Chess = chessModule.Chess;
 
           function checkMove(from, to, position) {

--- a/src/main/resources/blue-repository/Chess/ChessAssistedRemotely.blue
+++ b/src/main/resources/blue-repository/Chess/ChessAssistedRemotely.blue
@@ -71,7 +71,7 @@ workflows:
       - name: ProcessMove
         type: JavaScript Code Step
         code: |
-          const chessModule = importBlueESModule('blue:FQP53g6UNu75EeEDmTX8mKHqoNSLQgYxQxpFhAzKyHhJ');
+          const chessModule = importBlueESModule('blue:9uGqgr62FtodKDH1KqGb1syeqHfSRo7ySQ5KY8bTutNu');
           const Chess = chessModule.Chess;
 
           function checkMove(from, to, position) {

--- a/src/main/resources/blue-repository/Chess/ChessAssistedTwoPlayers.blue
+++ b/src/main/resources/blue-repository/Chess/ChessAssistedTwoPlayers.blue
@@ -73,7 +73,7 @@ workflows:
       - name: ProcessMove
         type: JavaScript Code Step
         code: |
-          const chessModule = importBlueESModule('blue:FQP53g6UNu75EeEDmTX8mKHqoNSLQgYxQxpFhAzKyHhJ');
+          const chessModule = importBlueESModule('blue:9uGqgr62FtodKDH1KqGb1syeqHfSRo7ySQ5KY8bTutNu');
           const Chess = chessModule.Chess;
 
           function checkMove(from, to, position) {


### PR DESCRIPTION
BREAKING CHANGE: All Blue IDs have been recalculated due to changes in blue-language-java

- BluePackageExporter: Update REPLACE_INLINE_TYPES_WITH_BLUE_ID_TRANSFORMER_BLUE_ID
- StandardProcessorsProvider: Fix processor Blue IDs
- Chess.blue, ChessAssisted.blue, ChessAssistedRemotely.blue, ChessAssistedTwoPlayers.blue: Adjust Chess module Blue ID

These changes align the project with the new blueId calculation method in blue-language-java, ensuring proper functionality and compatibility.